### PR TITLE
feat: bump EN to v27.0.0, disable snapshot recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The Zksync External Node [Docs](https://github.com/matter-labs/zksync-era/blob/m
 
 ### 2. External Node
 
-- **Image:** `matterlabs/external-node:2.0-v26.2.1`
+- **Image:** `matterlabs/external-node:2.0-v27.0.0`
 - **Depends on:** PostgreSQL service (ensures the service starts after PostgreSQL is healthy)
 - **Ports:**
   - `3054` (Consensus public port)

--- a/docker-compose/treasure-external-node.yml
+++ b/docker-compose/treasure-external-node.yml
@@ -52,7 +52,7 @@ services:
   # Generation of consensus secrets.
   # The secrets are generated iff the secrets file doesn't already exist.
   generate-secrets:
-    image: "matterlabs/external-node:2.0-v26.2.1"
+    image: "matterlabs/external-node:2.0-v27.0.0"
     entrypoint:
       [
       "./configs/generate_secrets.sh",
@@ -61,7 +61,7 @@ services:
     volumes:
       - ./configs:/configs
   external-node:
-    image: "matterlabs/external-node:2.0-v26.2.1"
+    image: "matterlabs/external-node:2.0-v27.0.0"
     entrypoint:
       [
       "/usr/bin/entrypoint.sh",
@@ -101,7 +101,7 @@ services:
 
       EN_STATE_CACHE_PATH: "./db/ext-node/state_keeper"
       EN_MERKLE_TREE_PATH: "./db/ext-node/lightweight"
-      EN_SNAPSHOTS_RECOVERY_ENABLED: "true"
+      EN_SNAPSHOTS_RECOVERY_ENABLED: "false"
       EN_SNAPSHOTS_OBJECT_STORE_BUCKET_BASE_URL: "zksync-era-mainnet-external-node-snapshots"
       EN_SNAPSHOTS_OBJECT_STORE_MODE: "GCSAnonymousReadOnly"
       RUST_LOG: "warn,zksync=info,zksync_core::metadata_calculator=debug,zksync_state=debug,zksync_utils=debug,zksync_web3_decl::client=error"

--- a/docker-compose/treasuretopaz-external-node.yml
+++ b/docker-compose/treasuretopaz-external-node.yml
@@ -52,7 +52,7 @@ services:
   # Generation of consensus secrets.
   # The secrets are generated iff the secrets file doesn't already exist.
   generate-secrets:
-    image: "matterlabs/external-node:2.0-v26.2.1"
+    image: "matterlabs/external-node:2.0-v27.0.0"
     entrypoint:
       [
       "./configs/generate_secrets.sh",
@@ -61,7 +61,7 @@ services:
     volumes:
       - ./configs:/configs
   external-node:
-    image: "matterlabs/external-node:2.0-v26.2.1"
+    image: "matterlabs/external-node:2.0-v27.0.0"
     entrypoint:
       [
       "/usr/bin/entrypoint.sh",
@@ -101,7 +101,7 @@ services:
 
       EN_STATE_CACHE_PATH: "./db/ext-node/state_keeper"
       EN_MERKLE_TREE_PATH: "./db/ext-node/lightweight"
-      EN_SNAPSHOTS_RECOVERY_ENABLED: "true"
+      EN_SNAPSHOTS_RECOVERY_ENABLED: "false"
       EN_SNAPSHOTS_OBJECT_STORE_BUCKET_BASE_URL: "zksync-era-boojnet-external-node-snapshots"
       EN_SNAPSHOTS_OBJECT_STORE_MODE: "GCSAnonymousReadOnly"
       RUST_LOG: "warn,zksync=info,zksync_core::metadata_calculator=debug,zksync_state=debug,zksync_utils=debug,zksync_web3_decl::client=error"


### PR DESCRIPTION
# Changelog
- Bump EN to v27.0.0 from v26.2.1
- Disable recovery from snapshot

In response to:

> Hi, we have released [EN v27.0.0](https://hub.docker.com/layers/matterlabs/external-node/v27.0.0/images/sha256-d31c797fe6a31902eddf9136592e8fd424087425417a959688ef75fb8c477d31) for the upcoming protocol upgrade v27. This is the mandatory EN version. You have to update your Era nodes to v27.0.0 before:
> March 31, 10:00 UTC for era testnet
> April 14, 10:00 UTC for era mainnet
> Please note that the upgrades may happen later than these days, but we guarantee that they will not happen earlier